### PR TITLE
Readme edits for FAC11

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ function updateDom (changeTransition) {
     visionimage.style.opacity = changeTransition ? 0 : 1
   }
 }
+
+var impureUpdateDom = updateDom(visionChange(changeTransition));
+
+// When we're ready...
+impureUpdateDom();
 ```
 
 These are two functions which we can easily test:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you are a member of FAC10 (the intended audience of this workshop) you might 
 
 In this example we create the empty array `soundObjects`. We then mutate it. Because this code isn't broken out into functions, and relies on global variables, it's very hard to test.
 
-```
+```js
 var sounds = [
   'http://www.soundjig.com/mp3/soundfx/human/aaaahhhh.mp3',
   'http://www.soundjig.com/mp3/soundfx/human/breath.mp3'
@@ -39,7 +39,7 @@ sounds.forEach(function (soundSrc) {
 
 In order to make this piece of functionality more testable, we can wrap it up in a function `makeSoundObjects` will take an array as an argument, and return a new array with the information we want. This means we can run tests with any array that we want, and that we can create our soundObjects in the form we want without ever having to mutate it.
 
-```
+```js
 // [] -> []
 function makeSoundObjects (sounds) {
   return sounds.map(function (soundSrc) {
@@ -54,7 +54,8 @@ var soundObjects = makeSoundObjects(sounds)
 Most programs we want to write wouldn't work if we completely disallow side effects. How then we can ensure that our impure functions are testable?
 
 This function takes no arguments, alters the dom based on the global variable `changeTransition`, then changes the the global variable `changeTransition`.
-```
+
+```js
 //VISIONTRANSITION
 
 var changeTransition = true;
@@ -80,8 +81,9 @@ Here we have rewritten the function to to be two seperate functions, both of whi
 
 The second function returns an impure function, which we can wait until the right moment and then call.
 
-Imagine our impure as being an unpredictable cannon, which we load in the safest way possible. Then eventually light the fuse, and run away from.  
-```
+Imagine our impure as being an unpredictable cannon, which we load in the safest way possible. Then eventually light the fuse, and run away from.
+
+```js
 function visionChange (changeTransition) {
   return changeTransition ? false : true
 }
@@ -95,8 +97,10 @@ function updateDom (changeTransition) {
   }
 }
 ```
+
 These are two functions which we can easily test
-```
+
+```js
 QUnit.test(`functions return our stuff`, (t) => {
   t.equal(visionChange(true), false);
   t.equal(visionChange(false), true);
@@ -104,6 +108,7 @@ QUnit.test(`functions return our stuff`, (t) => {
   t.equal(typeof updateDom(false), function)
 })
 ```
+
 We have now two easily testable functions, which we can chain together to get the same functionality we had before.
 
 ## Exercises!

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ I encourage you to fight through this inertia, as pure functions can have huge b
 
 If you've tried to start writing tests and struggled, it could well be that the code you are writing is simply _too hard to test_. If a function relies on global variables, it means your tests will have to set up global state, reset it for each test, and if a test fails it's hard to be sure exactly why.
 
-## Examples stolen from FAC10
-
-If you are a member of FAC10 (the intended audience of this workshop) you might recognise some of this code. Please don't be offended! You're all writing much better code than I was in your position.
+## Examples (stolen from FAC10)
 
 ### Example 1 - let's be declarative, let's get functional
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,19 @@ function updateDom (changeTransition) {
 These are two functions which we can easily test
 
 ```js
-QUnit.test(`functions return our stuff`, (t) => {
-  t.equal(visionChange(true), false);
-  t.equal(visionChange(false), true);
-  t.equal(typeof updateDom(true), function)
-  t.equal(typeof updateDom(false), function)
-})
+test('visionChange correctly switches boolean', function(t) {
+  var actual = visionChange(true);
+  var expected = false;
+  t.equal(actual, expected, 'Should return false when given true');
+  t.end();
+});
+
+test('updateDom returns correct type', function(t) {
+  var actual = typeof updateDom(true);
+  var expected = 'function';
+  t.equal(actual, expected, 'Should return a function' );
+  t.end();
+});
 ```
 
 We have now two easily testable functions, which we can chain together to get the same functionality we had before.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Pure functions - easy testing
+
 One of the biggest benefits of testing your code, is that you will be encouraged to write testable code. Testable code will tend to be predictable, readable, and split into small pure functions.
 
 If you've never written code in this way, it can be hard to start. This tutorial is intended to help people who are interested in testing their code learn how to start writing pure testable functions.
 
-In this tutorial I will assume a basic familiarity with Javascript, and enough knowledge of testing to understand the the syntax. If you've never written any tests, try [DWYL's tdd guide](https://github.com/dwyl/learn-tdd)
+In this tutorial I will assume a basic familiarity with Javascript, and enough knowledge of testing to understand the the syntax.
 
 ## Why should I write pure functions?
 
-If you are used to writing code which rely on global state, and utilise side effects, then writing pure functions can feel like imposing unecessary restrictions on yourself.
+If you are used to writing code which relies on global state and utilises side effects then writing pure functions can feel like imposing unnecessary restrictions on yourself.
 
-I encourage you to fight through this inertia, as pure functions can have huge benefits for your code. Today we will be focusing on one particular benefit
+I encourage you to fight through this inertia, as pure functions can have huge benefits for your code. Today we will be focusing on one particular benefit:
 
 **easy testing**
 
@@ -19,7 +20,7 @@ If you've tried to start writing tests and struggled, it could well be that the 
 
 If you are a member of FAC10 (the intended audience of this workshop) you might recognise some of this code. Please don't be offended! You're all writing much better code than I was in your position.
 
-### example 1 - let's be declarative, let's get functional
+### Example 1 - let's be declarative, let's get functional
 
 In this example we create the empty array `soundObjects`. We then mutate it. Because this code isn't broken out into functions, and relies on global variables, it's very hard to test.
 
@@ -50,10 +51,10 @@ function makeSoundObjects (sounds) {
 var soundObjects = makeSoundObjects(sounds)
 ```
 
-### example 3 - What if I need side effects?
-Most programs we want to write wouldn't work if we completely disallow side effects. How then we can ensure that our impure functions are testable?
+### Example 2 - What if I need side effects?
+Most programs we want to write wouldn't work if we completely disallowed side effects. How then we can ensure that our impure functions are testable?
 
-This function takes no arguments, alters the dom based on the global variable `changeTransition`, then changes the the global variable `changeTransition`.
+This function takes no arguments, alters the DOM based on the global variable `changeTransition`, then changes the the global variable `changeTransition`.
 
 ```js
 //VISIONTRANSITION
@@ -77,11 +78,11 @@ function visionChange () {
 
 }
 ```
-Here we have rewritten the function to to be two seperate functions, both of which will return the same value every time, when given the same argument.
+Here we have rewritten the function to to be two separate functions, both of which will return the same value every time, when given the same argument.
 
 The second function returns an impure function, which we can wait until the right moment and then call.
 
-Imagine our impure as being an unpredictable cannon, which we load in the safest way possible. Then eventually light the fuse, and run away from.
+Imagine our impure function as an unpredictable cannon, which we load in the safest way possible. We eventually light the fuse and run away.
 
 ```js
 function visionChange (changeTransition) {
@@ -98,7 +99,7 @@ function updateDom (changeTransition) {
 }
 ```
 
-These are two functions which we can easily test
+These are two functions which we can easily test:
 
 ```js
 test('visionChange correctly switches boolean', function(t) {
@@ -116,19 +117,19 @@ test('updateDom returns correct type', function(t) {
 });
 ```
 
-We have now two easily testable functions, which we can chain together to get the same functionality we had before.
+We now have two easily testable functions, which we can chain together to get the same functionality we had before.
 
 ## Exercises!
 
 * clone this repo
-* open specrunner.html in the broswer
+* open `specrunner.html` in the browser
 * appreciate the failing tests
-* open exercises/exercise1.js
-* refactor the functions, make the tests pass. It will be useful to open the tests and look at exactly what is expected.
+* open `exercises/exercise1.js`
+* refactor the functions to make the tests pass. It will be useful to open the tests and look at exactly what is expected.
 
 ## Glossary
 
-### pure functions
+### Pure functions
 
 A pure function takes in some number of arguments and then returns a value.
 
@@ -140,7 +141,7 @@ A pure function has no side effects. This means that simply calling the function
 
 A functions side effects are anything that it does beyond simply returning a value. For example this function has the side effect of changing a global variable
 
-```
+```js
 var age = 21
 
 function sideEffector () {
@@ -152,4 +153,4 @@ sideEffector()
 console.log(age) // 22
 ```
 
-Side effects also include making HTTP requests, and manipulating the DOM.
+Side effects also include making HTTP requests and manipulating the DOM.


### PR DESCRIPTION
Hi @Jwhiles!

We wanted to make a few tweaks to the Readme for FAC11, I hope that's okay.

+ Add syntax highlighting to code blocks, so they're easier to read
+ Tweak example tests to use the test style we're teaching (and remove QUnit reference, since we're teaching Tape)
+ Fix a few typos/grammar errors
+ Remove section directly addressing FAC10
+ Add an example to show how you'd call the `updateDom` function (relates #12)